### PR TITLE
Gmail integration Stage 1

### DIFF
--- a/src/components/EmailTemplate.vue
+++ b/src/components/EmailTemplate.vue
@@ -28,6 +28,8 @@
 </template>
 
 <script>
+  import { generateMimeEmail } from "@/utils/encodeEmail";
+
   export default {
     name: "EmailTemplate",
     props: {
@@ -54,15 +56,15 @@
         const rssHTML = this.emailTemplates
           .map(
             (email) => `
-                    <div class="rss-item-container">
-                      <h4>
-                        <a href="${email.link}" target="_blank" rel="noopener noreferrer">
-                          ${email.title}
-                        </a>
-                      </h4>
-                      <p>${email.desc}</p>
-                    </div>
-                  `
+                <div class="rss-item-container">
+                  <h4>
+                    <a href="${email.link}" target="_blank" rel="noopener noreferrer">
+                      ${email.title}
+                    </a>
+                  </h4>
+                  <p>${email.desc}</p>
+                </div>
+              `
           )
           .join("");
 
@@ -73,8 +75,17 @@
         this.editorContent = this.$refs.editor.innerHTML;
       },
       finalizeEmail() {
-        console.log("Finalized Email Content:", this.editorContent);
-        alert("Email has been finalized!");
+        this.updateEditorContent();
+
+        const emailData = {
+          from: "example@email.com",
+          to: "customer@email.com",
+          subject: "Recent Cloudinary Release Notes",
+          html: this.editorContent,
+        };
+
+        const encodedEmail = generateMimeEmail(emailData);
+        console.log("Encoded Email for Gmail API:", encodedEmail);
         this.closeTemplateModal();
       },
       closeModal() {

--- a/src/components/EmailTemplate.vue
+++ b/src/components/EmailTemplate.vue
@@ -77,15 +77,30 @@
       finalizeEmail() {
         this.updateEditorContent();
 
-        const emailData = {
-          from: "example@email.com",
-          to: "customer@email.com",
-          subject: "Recent Cloudinary Release Notes",
-          html: this.editorContent,
-        };
+        const subject = "Cloudinary's Latest Release Notes";
+        const htmlContent = this.editorContent;
 
-        const encodedEmail = generateMimeEmail(emailData);
-        console.log("Encoded Email for Gmail API:", encodedEmail);
+        navigator.clipboard.writeText(htmlContent).then(() => {
+          // ! Opens Gmail Compose in a new tab
+          const gmailUrl = `https://mail.google.com/mail/?view=cm&fs=1&su=${encodeURIComponent(
+            subject
+          )}&tf=1`;
+          window.open(gmailUrl, "_blank");
+
+          alert(
+            "Email HTML copied to clipboard. Paste it into the Gmail compose window!"
+          );
+        });
+        // *Encoding necessary for the eventual Google API implementation
+        // const emailData = {
+        //   from: "jonathan.sexton@cloudinary.com",
+        //   to: "jonathan.sexton@cloudinary.com",
+        //   subject: "Recent Cloudinary Release Notes",
+        //   html: this.editorContent,
+        // };
+
+        // const encodedEmail = generateMimeEmail(emailData);
+        // console.log("Encoded Email for Gmail API:", encodedEmail);
         this.closeTemplateModal();
       },
       closeModal() {

--- a/src/components/EmailTemplate.vue
+++ b/src/components/EmailTemplate.vue
@@ -56,19 +56,21 @@
         const rssHTML = this.emailTemplates
           .map(
             (email) => `
-                <div class="rss-item-container">
-                  <h4>
-                    <a href="${email.link}" target="_blank" rel="noopener noreferrer">
-                      ${email.title}
-                    </a>
-                  </h4>
-                  <p>${email.desc}</p>
-                </div>
-              `
+                <div style="max-width: 600px; margin: auto; font-family: Arial, sans-serif;">
+              <div style="margin-bottom: 20px; padding: 10px; border-bottom: 1px solid #ddd;">
+                <h4 style="margin: 0 0 10px 0; font-size: 16px;">
+                  <a href="${email.link}" target="_blank" rel="noopener noreferrer" style="color: #0073e6; text-decoration: none;">
+                    ${email.title}
+                  </a>
+                </h4>
+                <p style="margin: 0; font-size: 14px; line-height: 1.6;">${email.desc}</p>
+              </div>
+              </div>
+            `
           )
           .join("");
 
-        this.editorContent = `<p>Write your email content here...</p>${rssHTML}`;
+        this.editorContent = `<p style="font-family: Arial, sans-serif; font-size: 14px;">Write your email content here...</p>${rssHTML}`;
         this.$refs.editor.innerHTML = this.editorContent;
       },
       updateEditorContent() {

--- a/src/components/EmailTemplate.vue
+++ b/src/components/EmailTemplate.vue
@@ -56,14 +56,18 @@
         const rssHTML = this.emailTemplates
           .map(
             (email) => `
-                <div style="max-width: 600px; margin: auto; font-family: Arial, sans-serif;">
-              <div style="margin-bottom: 20px; padding: 10px; border-bottom: 1px solid #ddd;">
-                <h4 style="margin: 0 0 10px 0; font-size: 16px;">
+                <div style="max-width: 600px; font-family: Arial, sans-serif;">
+              <div style="margin-bottom: 20px; padding: 10px;">
+                <ul>
+                  <li>
+                    <h4 style="margin: 0 0 10px 0; font-size: 16px;">
                   <a href="${email.link}" target="_blank" rel="noopener noreferrer" style="color: #0073e6; text-decoration: none;">
                     ${email.title}
                   </a>
                 </h4>
                 <p style="margin: 0; font-size: 14px; line-height: 1.6;">${email.desc}</p>
+                    </li>
+                  </ul>
               </div>
               </div>
             `
@@ -72,6 +76,16 @@
 
         this.editorContent = `<p style="font-family: Arial, sans-serif; font-size: 14px;">Write your email content here...</p>${rssHTML}`;
         this.$refs.editor.innerHTML = this.editorContent;
+      },
+      copyHtmlToClipboard() {
+        const htmlContent = this.editorContent;
+
+        const blob = new Blob([htmlContent], { type: "text/html" });
+        const data = [new ClipboardItem({ "text/html": blob })];
+
+        navigator.clipboard.write(data).then(() => {
+          console.log("HTML copied as rich content!");
+        });
       },
       updateEditorContent() {
         this.editorContent = this.$refs.editor.innerHTML;
@@ -82,16 +96,13 @@
         const subject = "Cloudinary's Latest Release Notes";
         const htmlContent = this.editorContent;
 
-        navigator.clipboard.writeText(htmlContent).then(() => {
-          // ! Opens Gmail Compose in a new tab
-          const gmailUrl = `https://mail.google.com/mail/?view=cm&fs=1&su=${encodeURIComponent(
-            subject
-          )}&tf=1`;
-          window.open(gmailUrl, "_blank");
+        const blob = new Blob([htmlContent], { type: "text/html" });
+        const data = [new ClipboardItem({ "text/html": blob })];
 
-          alert(
-            "Email HTML copied to clipboard. Paste it into the Gmail compose window!"
-          );
+        navigator.clipboard.write(data).then(() => {
+          const subject = encodeURIComponent("Cloudinary Release Notes");
+          const gmailUrl = `https://mail.google.com/mail/?view=cm&fs=1&su=${subject}&tf=1`;
+          window.open(gmailUrl, "_blank");
         });
         // *Encoding necessary for the eventual Google API implementation
         // const emailData = {

--- a/src/components/FeedSelector.vue
+++ b/src/components/FeedSelector.vue
@@ -33,16 +33,19 @@
         </button>
       </div>
 
-      <div class="toolbar-center-group">
-        <p>Click to jump to section:</p>
-        <button class="toolbar-btn" :disabled="!pmGroupedItemsArray.length">
-          <a href="#pm-section">PM</a>
-        </button>
-        <button class="toolbar-btn" :disabled="!damGroupedItemsArray.length">
-          <a href="#dam-section">DAM</a>
-        </button>
-        <button class="toolbar-btn" :disabled="!intGroupedItemsArray.length">
-          <a href="#int-section">INT</a>
+      <div class="product-tabs">
+        <button
+          v-for="tab in tabs"
+          :key="tab"
+          @click="activeTab = tab"
+          :class="[
+            'tab-button',
+            tab.toLowerCase(),
+            { active: activeTab === tab },
+          ]"
+        >
+          {{ tab.toUpperCase() }}
+          <span class="tab-count">({{ tabItemCount(tab) }})</span>
         </button>
       </div>
 
@@ -75,7 +78,7 @@
       </div>
     </div>
 
-    <div class="product-tabs">
+    <!-- <div class="product-tabs">
       <button
         v-for="tab in tabs"
         :key="tab"
@@ -89,7 +92,7 @@
         {{ tab.toUpperCase() }}
         <span class="tab-count">({{ tabItemCount(tab) }})</span>
       </button>
-    </div>
+    </div> -->
 
     <div class="feed-content-scroll-container" id="pm-section">
       <div

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -3,23 +3,33 @@
     <div id="footer-top"></div>
     <div id="footer-bottom">
       <p>
-        Built with &hearts; and &#9749; by Jonathan Sexton -
-        <a href="https://github.com/JS-goose" rel="noopener noreferrer"
+        Built with &hearts; and &#9749; by the Scaled Team & Jonathan Sexton -
+        <a
+          href="https://github.com/JS-goose"
+          rel="noopener noreferrer"
+          target="_blank"
           >GitHub</a
         >&nbsp;|
         <a
           href="https://www.linkedin.com/in/jj-goose/"
           rel="noopener noreferrer"
+          target="_blank"
           >LinkedIn</a
         >
       </p>
       <p>
-        <a href="https://cloudinary.com/tou" rel="noopener noreferrer"
+        <a
+          href="https://cloudinary.com/tou"
+          rel="noopener noreferrer"
+          target="_blank"
           >Terms of Use</a
         >
       </p>
       <p>
-        <a href="https://cloudinary.com/privacy" rel="noopener noreferrer"
+        <a
+          href="https://cloudinary.com/privacy"
+          rel="noopener noreferrer"
+          target="_blank"
           >Privacy Policy</a
         >
       </p>
@@ -27,12 +37,18 @@
         <a
           href="https://cloudinary.com/product_updates"
           rel="noopener noreferrer"
+          target="_blank"
           >Product Updates</a
         >
       </p>
       <p>
-        &copy; {{ new Date().getUTCFullYear() }} Cloudinary. All rights
-        reserved.
+        &copy; {{ new Date().getUTCFullYear() }}
+        <a
+          href="https://cloudinary.com/"
+          rel="noopener noreferrer"
+          target="_blank"
+          >Cloudinary</a
+        >. All rights reserved.
       </p>
     </div>
   </footer>
@@ -73,10 +89,6 @@
 
   a:hover {
     color: white;
-  }
-
-  a:visited {
-    color: var(--cldLightBlue);
   }
 
   #footer-top,

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -6,7 +6,7 @@
         alt="Cloudinary"
       />
     </a>
-    <h1>RSS Feed to Email Template Generator</h1>
+    <h1>RSS Mailer - Template Generator</h1>
     <ul>
       <li>
         <a
@@ -21,7 +21,7 @@
           href="https://github.com/JS-goose/template-generator"
           target="_blank"
           rel="noreferrer noopener"
-          >Template Builder Documentation</a
+          >RSS Mailer Documentation</a
         >
       </li>
       <li>

--- a/src/utils/encodeEmail.js
+++ b/src/utils/encodeEmail.js
@@ -1,0 +1,18 @@
+import { Buffer } from 'buffer';
+
+function generateMimeEmail({from, to, subject, html}) {
+    const mime = [
+        `From: ${from}`,
+        `To: ${to}`,
+        `Subject: ${subject}`,
+        `Content-Type: text/html; charset=UTF-8`,
+        '',
+        html,
+    ].join('\r\n');
+
+    const base64Encoded = Buffer.from(mime).toString('base64').replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+
+    return base64Encoded;
+}

--- a/src/utils/encodeEmail.js
+++ b/src/utils/encodeEmail.js
@@ -1,6 +1,6 @@
 import { Buffer } from 'buffer';
 
-function generateMimeEmail({from, to, subject, html}) {
+export function generateMimeEmail({from, to, subject, html}) {
     const mime = [
         `From: ${from}`,
         `To: ${to}`,


### PR DESCRIPTION
Added Gmail support stage 1:

- Minor styling changes (removal of "jump to" tabs)
- User authorizes Gmail by logging into their account in separate modal
- Once successfully logged in and permissions granted, user can send emails from email template modal
- Upon clicking finalize email, template data is copied to clipboard
- Separate window opens showing Gmail composer
- User manually pastes data, adjusts email as they see fit and then sends the email
- RSS Mailer window stays open with data state preserved (intentional)